### PR TITLE
post /ccap/user shouldn't be public by default or require email

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The following endpoints are not REQUIRED to adhere to CCAP, because most of thos
 
 ### POST /ccap/user
 
-No Authorization (Public method)
+Authorization: Secret {secret}
 
 Create a new user on the server.
 
@@ -150,7 +150,7 @@ Create a new user on the server.
 | ---------- | ----------- | -------- | ------------ |
 | username | The username of the user | Yes | "lane"
 | password | The password of the user | Yes | "SU93Rc00lpa55"
-| email | The email of the user | Yes | "lane.wagner@gmail.com"
+| email | The email of the user | no | "lane.wagner@gmail.com"
 | ... | If additional information is required for sign-ups, then this endpoint shouldn't be used. Clients should sign up via a custom front-end portal of some sort. | ... | ...
 
 #### Example Response


### PR DESCRIPTION
An email requirement is bloat as it is never used anywhere in the required endpoints and /ccap/user shouldn't be public by default. It should instead use a secret key or password